### PR TITLE
Fix SemVer link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Please note that this project is released with a [Contributor Code of Conduct](C
 
 ## Versioning
 
-We use [SemVer](http://semver.io/) for the version tags available See the tags on this repository. 
+We use [SemVer](http://semver.org/) for the version tags available See the tags on this repository. 
 
 ## Authors
 


### PR DESCRIPTION
Semver.io is a tool, semver.org is the actual definition
